### PR TITLE
Update correct github project url

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * A Node.js wrapper for the Matomo (http://matomo.org) tracking HTTP API
- * https://github.com/matomo-org/matomo-tracker
+ * https://github.com/matomo-org/matomo-nodejs-tracker
  *
  * @author  Frederic Hemberger, Matomo Team
  * @license MIT


### PR DESCRIPTION
Avoid 404 Error.
Changed https://github.com/matomo-org/matomo-tracker to https://github.com/matomo-org/matomo-nodejs-tracker