### PR TITLE
fix: treat 204 responses as a success on track function

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ MatomoTracker.prototype.track = function track (options) {
   var self = this;
   var req = this.agent.get(requestUrl, function (res) {
     // Check HTTP statuscode for 200 and 30x
-    if (!/^(200|30[12478])$/.test(res.statusCode)) {
+    if (!/^(20[04]|30[12478])$/.test(res.statusCode)) {
       if (hasErrorListeners) {
         self.emit('error', res.statusCode);
       }


### PR DESCRIPTION
This is a follow-up to #57. 

As per the comment and report at https://github.com/matomo-org/matomo-nodejs-tracker/commit/cb7656601b5cdabcf27a3c836a971d3bf0e7b81a#commitcomment-41747166, I previously only fixed the `trackBulk` request, and not the individual `track` request. This applies the same fix to the `track` request.

